### PR TITLE
Easier installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This software is the *web-service* version, meaning it's aimed at people who mak
 
 ## Developers of systematic review software?
 
-RobotReviewer is open source and free to use under the GPL licence, version 3.0 (see the LICENCE.txt file in this directory).
+RobotReviewer is open source and free to use under the GPL license, version 3.0 (see the LICENSE.txt file in this directory).
 
 We offer RobotReviewer free of charge, but we'd be most grateful if you would cite us if you use it. We're academics, and thrive on links and citations! Getting RobotReviewer widely used and cited helps us obtain the funding to maintain the project and make RobotReviewer better.
 
@@ -45,7 +45,7 @@ A BibTeX entry for LaTeX users is
 
 ## Installation
 
-An automatic installation is currently supported for OS X. This will automatically create a new [conda](d) environment and install the required dependencies into it.
+An automatic installation is currently supported for OS X. This will automatically create a new [conda](https://www.anaconda.com/download/) environment and install the required dependencies into it.
 
 1. Ensure you have a working version of 3.4+. We strongly recommend using Python from the [Anaconda Python distribution](https://www.continuum.io/downloads) for a quicker and more reliable experience.
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ An automatic installation is currently supported for OS X. This will automatical
 
 ## Manual Installation
 
+For other operating systems or for more control, a manual installation may be preferred.
+
 1. Ensure you have a working version of 3.4+. We strongly recommend using Python from the [Anaconda Python distribution](https://www.continuum.io/downloads) for a quicker and more reliable experience.
 
 2. [Install git-lfs](https://git-lfs.github.com/) for managing the model file versions (on Mac: `brew install git-lfs`). NB! If you already have git lfs installed, make sure it's the most recent version, since older versions have not downloaded files properly.

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ An automatic installation is currently supported for OS X. This will automatical
 
 4. Install the Python libraries that RobotReviewer needs. The most reliable way is through a conda environment. The following downloads the packages, and installs the required data.
     ```bash
-    conda env create -f robotreviewer_env.yml
+    conda env create -f robotreviewer_env_local.yml
     source activate robotreviewer
     python -m spacy.en.download
     python -m nltk.downloader punkt

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ An automatic installation is currently supported for OS X. This will automatical
 
 1. Ensure you have a working version of 3.4+. We strongly recommend using Python from the [Anaconda Python distribution](https://www.continuum.io/downloads) for a quicker and more reliable experience.
 
-2. Ensure you have the following requirements: [brew](https://brew.sh/), [Grobid](https://grobid.readthedocs.io/en/latest/Install-Grobid/).
+2. Ensure you have the following requirements: [Homebrew](https://brew.sh/), [Grobid](https://grobid.readthedocs.io/en/latest/Install-Grobid/).
 
 3. Get a copy of the RobotReviewer repo:
     ```bash
@@ -147,6 +147,10 @@ Feel free to contact us at [mail@ijmarshall.com](mailto:mail@ijmarshall) with an
 
 ##### Grobid isn't working properly
 Most likely the problem is that your path to Grobid in `robotreviewer/config.json` is incorrect. If your path uses a `~`, try using a path without one.
+
+##### rabbitmq-server: command not found
+Often found on OS X. If you installed `rabbitmq` using Homebrew, running the command `brew services start rabbitmq` should work.
+
 
 ## References
 

--- a/README.md
+++ b/README.md
@@ -45,11 +45,11 @@ A BibTeX entry for LaTeX users is
 
 ## Installation
 
-An automatic installation is currently supported for OS X.
+An automatic installation is currently supported for OS X. This will automatically create a new [conda](d) environment and install the required dependencies into it.
 
 1. Ensure you have a working version of 3.4+. We strongly recommend using Python from the [Anaconda Python distribution](https://www.continuum.io/downloads) for a quicker and more reliable experience.
 
-2. Ensure you have the following requirements: [brew](ht), [Grobid](https://grobid.readthedocs.io/en/latest/Install-Grobid/).
+2. Ensure you have the following requirements: [brew](https://brew.sh/), [Grobid](https://grobid.readthedocs.io/en/latest/Install-Grobid/).
 
 3. Get a copy of the RobotReviewer repo:
     ```bash
@@ -90,7 +90,7 @@ An automatic installation is currently supported for OS X.
 
 ## Running
 
-RobotReviewer requires a 'worker' process (which does the Machine Learning), and a webserver to be started.
+RobotReviewer requires a 'worker' process (which does the Machine Learning), and a webserver to be started. Ensure that you are within the conda environment (default name: robotreviewer) when running the following processes.
 
 First, be sure that rabbitmq-server is running. If you haven't set this to start on login, you can invoke manually:
 
@@ -142,6 +142,11 @@ will run the testing modules. These should be used to assure that changes made d
 ## Help
 
 Feel free to contact us at [mail@ijmarshall.com](mailto:mail@ijmarshall) with any questions.
+
+### Common Problems
+
+##### Grobid isn't working properly
+Most likely the problem is that your path to Grobid in `robotreviewer/config.json` is incorrect. If your path uses a `~`, try using a path without one.
 
 ## References
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,23 @@ A BibTeX entry for LaTeX users is
 
 ## Installation
 
+An automatic installation is currently supported for OS X.
+
+1. Ensure you have a working version of 3.4+. We strongly recommend using Python from the [Anaconda Python distribution](https://www.continuum.io/downloads) for a quicker and more reliable experience.
+
+2. Ensure you have the following requirements: [brew](ht), [Grobid](https://grobid.readthedocs.io/en/latest/Install-Grobid/).
+
+3. Get a copy of the RobotReviewer repo:
+    ```bash
+    git clone https://github.com/ijmarshall/robotreviewer3.git
+    cd robotreviewer3
+    ```
+
+4. Run the setup script with `. ./setup.sh`
+
+
+## Manual Installation
+
 1. Ensure you have a working version of 3.4+. We strongly recommend using Python from the [Anaconda Python distribution](https://www.continuum.io/downloads) for a quicker and more reliable experience.
 
 2. [Install git-lfs](https://git-lfs.github.com/) for managing the model file versions (on Mac: `brew install git-lfs`). NB! If you already have git lfs installed, make sure it's the most recent version, since older versions have not downloaded files properly.
@@ -75,7 +92,7 @@ A BibTeX entry for LaTeX users is
 
 RobotReviewer requires a 'worker' process (which does the Machine Learning), and a webserver to be started.
 
-First, be sure that rabbitmq-server is running. If you haven't set this to start on login, you can invoke manually: 
+First, be sure that rabbitmq-server is running. If you haven't set this to start on login, you can invoke manually:
 
 ```rabbitmq-server```
 

--- a/robotreviewer/config.json.example
+++ b/robotreviewer/config.json.example
@@ -1,11 +1,10 @@
 {
     "robotreviewer": {
         "use_grobid": true,
-        "grobid_path": "~/grobid-grobid-parent-0.4.1",
+        "grobid_path": "/Users/Robot/grobid",
         "grobid_host": "http://localhost:8080",
         "grobid_threads": 8,
         "spacy_threads": 8,
         "dont_delete": 0
 	}
 }
-

--- a/robotreviewer_env.yml
+++ b/robotreviewer_env.yml
@@ -1,6 +1,5 @@
 name: robotreviewer
 dependencies:
-- system
 - mkl
 - mkl-service
 - python=3.5

--- a/robotreviewer_env.yml
+++ b/robotreviewer_env.yml
@@ -1,6 +1,6 @@
 name: robotreviewer
 dependencies:
-- server
+- system
 - mkl
 - mkl-service
 - python=3.5

--- a/robotreviewer_env_local.yml
+++ b/robotreviewer_env_local.yml
@@ -1,6 +1,5 @@
 name: robotreviewer
 dependencies:
-- server
 - mkl
 - mkl-service
 - python=3.5

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,41 @@
+import json
+import logging
+import pip
+import os
+import shutil
+
+
+def create_config():
+    shutil.copyfile('robotreviewer/config.json.example', 'robotreviewer/config.json')
+    with open('robotreviewer/config.json', 'r') as f:
+        obj = json.load(f)
+    print('Please enter path to grobid:')
+    print('EXAMPLE: {}'.format('/Users/Robot/Documents/grobid'))
+    path = input()
+    obj['robotreviewer']['grobid_path'] = path
+    with open('robotreviewer/config.json', 'w') as f:
+        json.dump(obj, f, indent=4, separators=(',', ': '))
+
+
+if __name__ == '__main__':
+    print('Installing nltk.punkt...')
+    # Install punkt from nltk
+    import nltk
+    nltk.download('punkt')
+    print('Done installing nltk.punkt.\n')
+
+    print('Ensuring Keras backend is set to theano.')
+    # Ensure Keras backend is Theano
+    os.environ['KERAS_BACKEND'] = 'theano'
+    print('')
+
+    # Create config file
+    print('Setting up configuration file...')
+    if not os.path.isfile('robotreviewer/config.json'):
+        create_config()
+    print('')
+
+    print('Installing spacy.en...')
+    # Install spacy.en
+    from spacy.en import download
+    download.main()

--- a/setup.py
+++ b/setup.py
@@ -34,8 +34,3 @@ if __name__ == '__main__':
     if not os.path.isfile('robotreviewer/config.json'):
         create_config()
     print('')
-
-    print('Installing spacy.en...')
-    # Install spacy.en
-    from spacy.en import download
-    download.main()

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,17 @@
+echo "Creating conda environment.."
+conda env create -f robotreviewer_env.yml
+echo "Done.\n\n"
+
+echo "Setting up requirements.."
+source activate robotreviewer3
+python setup.py
+echo "Done.\n\n"
+
+echo "Starting up rabbitmq.."
+brew update
+brew install rabbitmq
+brew services start rabbitmq
+echo "Started."
+
+source deactivate
+echo "Setup finished."

--- a/setup.sh
+++ b/setup.sh
@@ -1,5 +1,5 @@
 echo "Creating conda environment.."
-conda env create -f robotreviewer_env.yml
+conda env create -f robotreviewer_env_local.yml
 echo "Done.\n\n"
 
 echo "Setting up requirements.."

--- a/setup.sh
+++ b/setup.sh
@@ -1,17 +1,21 @@
 echo "Creating conda environment.."
 conda env create -f robotreviewer_env_local.yml
-echo "Done.\n\n"
+echo "Done."
 
 echo "Setting up requirements.."
 source activate robotreviewer3
 python setup.py
-echo "Done.\n\n"
+echo "Done."
 
 echo "Starting up rabbitmq.."
 brew update
 brew install rabbitmq
 brew services start rabbitmq
 echo "Started."
+
+echo "Installing spacy requirements.."
+python -m spacy.en.download
+echo "Done."
 
 source deactivate
 echo "Setup finished."

--- a/setup.sh
+++ b/setup.sh
@@ -3,7 +3,7 @@ conda env create -f robotreviewer_env_local.yml
 echo "Done."
 
 echo "Setting up requirements.."
-source activate robotreviewer3
+source activate robotreviewer
 python setup.py
 echo "Done."
 


### PR DESCRIPTION
This PR adds a new script, `setup.sh` that can be run to automatically install RR and its requirements. At the moment works only for OS X, but it's a start.